### PR TITLE
Can't use the oldid and page attributes together

### DIFF
--- a/lib/iso3166.ex
+++ b/lib/iso3166.ex
@@ -2,7 +2,7 @@ defmodule ISO3166 do
   @title "ISO_3166-1"
   @section "4"
   @revid "690144849"
-  @url "https://en.wikipedia.org/w/api.php?action=parse&section=#{@section}&prop=text&page=#{@title}&format=json&formatversion=2&oldid=#{@revid}"
+  @url "https://en.wikipedia.org/w/api.php?action=parse&section=#{@section}&prop=text&format=json&formatversion=2&oldid=#{@revid}"
 
   @region_file_name Path.expand("../priv/ISO_3166-2.csv", __DIR__)
   @file_cache Path.expand("../priv/#{@title}.#{@section}.#{@revid}.html", __DIR__)


### PR DESCRIPTION
While testing the Elixir 1.4 fix I noticed compilation was failing when grabbing the HTML to cache from Wikipedia. I investigated and found it was now returning this:

```json
{"error":{"code":"invalidparammix","info":"The parameters \"page\" and \"oldid\" can not be used together.","docref":"See https://en.wikipedia.org/w/api.php for API usage."},"servedby":"mw1197"}
```

Reading over the Wikipedia API docs it seems `oldid` should be sufficient.